### PR TITLE
Remove redundant call to 'has()' to increase read performance.

### DIFF
--- a/src/FallbackAdapter.php
+++ b/src/FallbackAdapter.php
@@ -218,8 +218,10 @@ class FallbackAdapter implements AdapterInterface
      */
     public function read($path)
     {
-        if ($this->mainAdapter->has($path)) {
-            return $this->mainAdapter->read($path);
+        $result = $this->mainAdapter->read($path);
+
+        if (false !== $result) {
+            return $result;
         }
 
         $result = $this->fallback->read($path);
@@ -236,8 +238,10 @@ class FallbackAdapter implements AdapterInterface
      */
     public function readStream($path)
     {
-        if ($this->mainAdapter->has($path)) {
-            return $this->mainAdapter->readStream($path);
+        $result = $this->mainAdapter->readStream($path);
+
+        if (false !== $result) {
+            return $result;
         }
 
         $result = $this->fallback->readStream($path);

--- a/tests/FallbackAdapterTests.php
+++ b/tests/FallbackAdapterTests.php
@@ -148,8 +148,7 @@ class FallbackAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function testRead_PathExistsInMain()
     {
-        $this->mainAdapter->shouldReceive('has')->atLeast(1)->andReturn(true);
-        $this->mainAdapter->shouldReceive('read')->atLeast(1)->andReturn(true);
+        $this->mainAdapter->shouldReceive('read')->once()->andReturn(true);
 
         $this->fallbackAdapter->shouldNotReceive('read');
 
@@ -158,10 +157,9 @@ class FallbackAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function testRead_PathExistsInFallback()
     {
-        $this->mainAdapter->shouldReceive('has')->atLeast(1)->andReturn(false);
-        $this->mainAdapter->shouldNotReceive('read');
+        $this->mainAdapter->shouldReceive('read')->once()->andReturn(false);
 
-        $this->fallbackAdapter->shouldReceive('read')->atLeast(1)->andReturn(true);
+        $this->fallbackAdapter->shouldReceive('read')->once()->andReturn(true);
 
         $this->assertTrue($this->adapter->read('/path'));
     }


### PR DESCRIPTION
As mentioned in #1 
I've limited the change to read() and readStream(). The Flysystem API isn't very clear on how methods should respond to actions on files that don't exist. Sometimes an Exception is thrown, sometimes `false` is returned.

The read\* methods benefit the most from these changes.
