### PR TITLE
Revert "Remove redundant call to 'has()' to increase read performance."

### DIFF
--- a/src/FallbackAdapter.php
+++ b/src/FallbackAdapter.php
@@ -218,10 +218,8 @@ class FallbackAdapter implements AdapterInterface
      */
     public function read($path)
     {
-        $result = $this->mainAdapter->read($path);
-
-        if (false !== $result) {
-            return $result;
+        if ($this->mainAdapter->has($path)) {
+            return $this->mainAdapter->read($path);
         }
 
         $result = $this->fallback->read($path);
@@ -238,10 +236,8 @@ class FallbackAdapter implements AdapterInterface
      */
     public function readStream($path)
     {
-        $result = $this->mainAdapter->readStream($path);
-
-        if (false !== $result) {
-            return $result;
+        if ($this->mainAdapter->has($path)) {
+            return $this->mainAdapter->readStream($path);
         }
 
         $result = $this->fallback->readStream($path);

--- a/tests/FallbackAdapterTests.php
+++ b/tests/FallbackAdapterTests.php
@@ -148,7 +148,8 @@ class FallbackAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function testRead_PathExistsInMain()
     {
-        $this->mainAdapter->shouldReceive('read')->once()->andReturn(true);
+        $this->mainAdapter->shouldReceive('has')->atLeast(1)->andReturn(true);
+        $this->mainAdapter->shouldReceive('read')->atLeast(1)->andReturn(true);
 
         $this->fallbackAdapter->shouldNotReceive('read');
 
@@ -157,9 +158,10 @@ class FallbackAdapterTests extends \PHPUnit_Framework_TestCase
 
     public function testRead_PathExistsInFallback()
     {
-        $this->mainAdapter->shouldReceive('read')->once()->andReturn(false);
+        $this->mainAdapter->shouldReceive('has')->atLeast(1)->andReturn(false);
+        $this->mainAdapter->shouldNotReceive('read');
 
-        $this->fallbackAdapter->shouldReceive('read')->once()->andReturn(true);
+        $this->fallbackAdapter->shouldReceive('read')->atLeast(1)->andReturn(true);
 
         $this->assertTrue($this->adapter->read('/path'));
     }


### PR DESCRIPTION
This reverts commit ea2c8873. See #1 

This changed caused problems because `file_get_contents` triggers a warning when the file doesn't exist.